### PR TITLE
Jinay/fix onboarding flow

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -30,7 +30,9 @@ function AuthCallbackContent() {
         
         // verify we have the required tokens
         if (!access_token || !refresh_token) {
-          throw new Error('Email verification failed - missing authentication tokens');
+          console.log('No verification tokens, redirecting to login');
+          router.push('/login');
+          return;
         }
         
         // start process of passing the tokens to supabase to set the session
@@ -43,6 +45,7 @@ function AuthCallbackContent() {
         });
 
         if (sessionError) {
+          console.error('Session error:', sessionError);
           throw sessionError;
         }
 
@@ -50,6 +53,8 @@ function AuthCallbackContent() {
           throw new Error('Email verification failed - no valid session created');
         }
 
+        const session = data.session;
+        console.log('Session established for user:', session.user.id);
         setStatus('Email verified! Setting up your account...');
 
         // Redirect to onboarding-profile

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -1,100 +1,76 @@
 'use client';
 
 import { useEffect, useState, Suspense } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase/client';
-import { checkOnboardingStatus } from '@/lib/auth';
 import { Loader2 } from 'lucide-react';
 
 function AuthCallbackContent() {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const [status, setStatus] = useState('Verifying your email...');
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function handleAuth() {
-      try {
-        console.log('Auth callback started');
+      try {        
+        // parse hash fragment (parameters after #)
+        // supabase sends tokens in the URL hash for email verification
+        const hashParams = new URLSearchParams(window.location.hash.substring(1));
         
-        // Check if searchParams is available
-        if (!searchParams) {
-          console.error('Search parameters not available');
-          throw new Error('Search parameters not available');
-        }
-
-        // First, handle the auth callback with the URL parameters
-        const code = searchParams.get('code');
-        const error_param = searchParams.get('error');
-        const error_description = searchParams.get('error_description');
-        
-        console.log('URL params:', { code: !!code, error_param, error_description });
-        
-        // Check for error parameters first
+        // extracts the Supabase tokens from URL hash
+        const access_token = hashParams.get('access_token');
+        const refresh_token = hashParams.get('refresh_token');
+        const error_param = hashParams.get('error');
+        const error_description = hashParams.get('error_description');
+               
+        // check for error parameters first
         if (error_param) {
           throw new Error(error_description || error_param);
         }
         
-        if (!code) {
-          // If no code but no error either, user might have clicked verification link without params
-          // Redirect to login instead of showing error
-          console.log('No verification code, redirecting to login');
-          router.push('/login');
-          return;
+        // verify we have the required tokens
+        if (!access_token || !refresh_token) {
+          throw new Error('Email verification failed - missing authentication tokens');
         }
-
-        setStatus('Verifying your account...');
-        console.log('Exchanging code for session');
         
-        const { data, error: exchangeError } = await supabase.auth.exchangeCodeForSession(code);
-
-        console.log('Exchange result:', { 
-          hasData: !!data, 
-          hasSession: !!data?.session, 
-          hasUser: !!data?.user,
-          error: exchangeError 
+        // start process of passing the tokens to supabase to set the session
+        setStatus('Verifying your account...');
+        
+        // Set the session using the tokens from the hash
+        const { data, error: sessionError } = await supabase.auth.setSession({
+          access_token,
+          refresh_token,
         });
 
-        if (exchangeError) {
-          console.error('Exchange error:', exchangeError);
-          throw exchangeError;
+        if (sessionError) {
+          throw sessionError;
         }
 
         if (!data.session || !data.user) {
           throw new Error('Email verification failed - no valid session created');
         }
 
-        const session = data.session;
-        console.log('Session established for user:', session.user.id);
         setStatus('Email verified! Setting up your account...');
 
-        // For new users after email verification, always redirect to onboarding
-        // The onboarding-profile page will handle checking existing profile data
+        // Redirect to onboarding-profile
         setStatus('Redirecting to complete your profile...');
         
-        // Shorter delay for better UX
         setTimeout(() => {
-          console.log('Redirecting to onboarding-profile');
           router.push('/onboarding-profile');
         }, 500);
         
       } catch (err) {
-        console.error('Auth callback error:', err);
         const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred';
-        console.error('Error details:', errorMessage);
         setError(errorMessage);
         
-        // Redirect to login after error with more info
         setTimeout(() => {
-          console.log('Redirecting to login due to error');
           router.push(`/login?error=${encodeURIComponent(errorMessage)}`);
         }, 3000);
       }
     }
 
     handleAuth();
-  }, [router, searchParams]);
-
+  }, [router]);
 
   return (
     <div className="min-h-screen flex items-center justify-center">

--- a/app/onboarding-profile/page.tsx
+++ b/app/onboarding-profile/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { ChevronLeft, Loader2, Check } from "lucide-react"
 import { getCurrentUser, createUserProfile, checkOnboardingStatus, getAndClearSignupData } from "@/lib/auth"
@@ -24,7 +24,18 @@ export default function OnboardingProfile() {
     { id: 'savoury,indulgent', label: 'Breakfast burrito', image: '/onboarding-option4.jpg' }
   ]
 
+  // inorder to avoid computing auth twice
+  const hasCheckedAuth = useRef(false)
+
   useEffect(() => {
+    // since react runs effects twice in dev mode,
+    // if auth has already been checked, skip
+    if (hasCheckedAuth.current) {
+      return
+    }
+    
+    hasCheckedAuth.current = true
+
     async function checkAuth() {
       try {
         const currentUser = await getCurrentUser()
@@ -35,41 +46,50 @@ export default function OnboardingProfile() {
         
         setUser(currentUser)
         
-        // Try to get stored signup data first
+        // Read localStorage directly
         let signupData = null
+        const storageKey = `signup_${currentUser.id}`
+        
         try {
-          signupData = getAndClearSignupData(currentUser.id)
+          const storedData = localStorage.getItem(storageKey)
+          
+          // check if onboarding successfully stored data
+          if (storedData) {
+            signupData = JSON.parse(storedData)
+          }
         } catch (jsonError) {
           showNotification('Error loading signup data. Proceeding with manual setup.')
         }
         
-        if (signupData) {
-          // User just signed up and verified email - skip to taste preference
+        if (signupData && signupData.firstName) {
           setFirstName(signupData.firstName)
           setUsername(signupData.username)
-          setStep('tastePreference') // Skip first name, go straight to breakfast
-        } else {
-          // Check what onboarding steps are needed for existing users
-          const status = await checkOnboardingStatus(currentUser.id)
+          setStep('tastePreference')
           
-          if (!status.needsOnboarding) {
-            // Already completed onboarding
-            router.push('/home')
-            return
-          }
-          
-          // Determine which step to show
-          if (!status.hasFirstName) {
+          // clears local storage to ensure no memory leaks within browser
+          localStorage.removeItem(storageKey)
+        } else {  
+          try {
+            const status = await checkOnboardingStatus(currentUser.id)
+            
+            if (!status.needsOnboarding) {
+              router.push('/home')
+              return
+            }
+            
+            if (!status.hasFirstName) {
+              setStep('firstName')
+            } else if (!status.hasTastePreference) {
+              setStep('tastePreference')
+            } else {
+              setStep('complete')
+            }
+          } catch (statusError) {
             setStep('firstName')
-          } else if (!status.hasTastePreference) {
-            setStep('tastePreference')
-          } else {
-            setStep('complete')
           }
         }
         
       } catch (error) {
-        console.error('Error checking auth:', error)
         showNotification('Error loading profile. Please try again.')
         router.push('/login')
       } finally {

--- a/app/onboarding-profile/page.tsx
+++ b/app/onboarding-profile/page.tsx
@@ -46,50 +46,41 @@ export default function OnboardingProfile() {
         
         setUser(currentUser)
         
-        // Read localStorage directly
+        // Try to get stored signup data first
         let signupData = null
-        const storageKey = `signup_${currentUser.id}`
-        
         try {
-          const storedData = localStorage.getItem(storageKey)
-          
-          // check if onboarding successfully stored data
-          if (storedData) {
-            signupData = JSON.parse(storedData)
-          }
+          signupData = getAndClearSignupData(currentUser.id)
         } catch (jsonError) {
           showNotification('Error loading signup data. Proceeding with manual setup.')
         }
         
-        if (signupData && signupData.firstName) {
+        if (signupData) {
+          // User just signed up and verified email - skip to taste preference
           setFirstName(signupData.firstName)
           setUsername(signupData.username)
-          setStep('tastePreference')
+          setStep('tastePreference') // Skip first name, go straight to breakfast
+        } else {
+          // Check what onboarding steps are needed for existing users
+          const status = await checkOnboardingStatus(currentUser.id)
           
-          // clears local storage to ensure no memory leaks within browser
-          localStorage.removeItem(storageKey)
-        } else {  
-          try {
-            const status = await checkOnboardingStatus(currentUser.id)
-            
-            if (!status.needsOnboarding) {
-              router.push('/home')
-              return
-            }
-            
-            if (!status.hasFirstName) {
-              setStep('firstName')
-            } else if (!status.hasTastePreference) {
-              setStep('tastePreference')
-            } else {
-              setStep('complete')
-            }
-          } catch (statusError) {
+          if (!status.needsOnboarding) {
+            // Already completed onboarding
+            router.push('/home')
+            return
+          }
+          
+          // Determine which step to show
+          if (!status.hasFirstName) {
             setStep('firstName')
+          } else if (!status.hasTastePreference) {
+            setStep('tastePreference')
+          } else {
+            setStep('complete')
           }
         }
         
       } catch (error) {
+        console.error('Error checking auth:', error)
         showNotification('Error loading profile. Please try again.')
         router.push('/login')
       } finally {

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -106,7 +106,7 @@ export default function SignUp() {
     e.preventDefault()
     
     if (!validateForm()) return
-
+  
     setLoading(true)
     
     try {
@@ -116,7 +116,18 @@ export default function SignUp() {
         firstName: formData.firstName,
         username: formData.username
       })
-
+  
+      // temporarily stores name and username in localStorage to use in onboarding profile verification
+      // no sensitive info is stored
+      if (result.user) {
+        if (typeof window !== 'undefined') {
+          localStorage.setItem(`signup_${result.user.id}`, JSON.stringify({
+            firstName: formData.firstName,
+            username: formData.username
+          }))
+        }
+      }
+  
       if (result.needsEmailVerification) {
         setStep('verification')
         // Set initial cooldown

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -106,7 +106,7 @@ export default function SignUp() {
     e.preventDefault()
     
     if (!validateForm()) return
-  
+
     setLoading(true)
     
     try {
@@ -116,30 +116,16 @@ export default function SignUp() {
         firstName: formData.firstName,
         username: formData.username
       })
-  
-      // temporarily stores name and username in localStorage to use in onboarding profile verification
-      // no sensitive info is stored
-      if (result.user) {
-        if (typeof window !== 'undefined') {
-          localStorage.setItem(`signup_${result.user.id}`, JSON.stringify({
-            firstName: formData.firstName,
-            username: formData.username
-          }))
-        }
-      }
-  
+
       if (result.needsEmailVerification) {
         setStep('verification')
         // Set initial cooldown
         const { remainingSeconds } = getResendCooldownTime(formData.email)
         setResendCountdown(remainingSeconds)
-      } else if (result.user && result.signupData) {
+      } else {
         // User is automatically logged in (email confirmation disabled)
-        // Store signup data for onboarding
         showNotification("Account created successfully!")
         router.push('/onboarding-profile')
-      } else {
-        throw new Error('Unexpected signup result - please try again')
       }
     } catch (error: any) {
       console.error('Signup error:', error)


### PR DESCRIPTION
this commit fixes the new user onboarding flow, fixing the extra login and redundant first name steps.

the problem was Supabase sends access/refresh tokens in hashParameters, however the old callback function tried to parse searchParameters. This commit implements the correct hash parameter parsing, to read these tokens and ensure the back-end knows the user has already created an account/logged in correctly, skipping the extra login step.

second, this commit helps skip the extra what's your first name step, caused by React's inbuilt double execution of effects. before the localStorage would be cleared and on the 2nd execution it would show the user didn't input a first name. used a switch to ensure the firstName parameter is correctly seen/read by the function on 2nd execution as well. 